### PR TITLE
Small language fix to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 * Improve Ethereum usability with distributed database infrastructure that works in production today
 
 ## 3Box DB
-3Box DB consists of two components: [`3box-js`](https://www.github.com/uport-project/3box-js) which is a client library, and [`3box-hash-server`](https://www.github.com/uport-project/3box-hash-server) which is a server. Together they are used to keep track of user data stored in [`orbit-db`](https://github.com/orbitdb/orbit-db) instances. Learn more about the [3Box architecture and how we do encryption](./ARCHITECTURE.md).
+3Box DB consists of two components: [`3box-js`](https://www.github.com/uport-project/3box-js) which is a client library, and [`3box-hash-server`](https://www.github.com/uport-project/3box-hash-server) which is a server. Together they are used to keep track of user data stored in [`orbit-db`](https://github.com/orbitdb/orbit-db) instances. Learn more about the [3Box architecture and how we do access control with encryption](./ARCHITECTURE.md).
 
 ### 3Box JS
 [`3box-js`](https://www.github.com/uport-project/3box-js) (coming soon) is the client side library used to read, write, and delete public and private data associated with the user. This library is used to get profile information about an address.


### PR DESCRIPTION
This clarifies language around access control with encryption, and completes @christianlundkvist's PR for adding access control to the architecture doc.